### PR TITLE
Makes robots robotic

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -7,10 +7,12 @@
 	blacklisted = 0
 	sexes = 0
 	species_traits = list(MUTCOLORS,NOEYES,NOTRANSSTING)
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH)
+	burnmod = 2
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna")
 	default_features = list("ipc_screen" = "Blank", "ipc_antenna" = "None")
-	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
+	meat = null
 	gib_types = list(/obj/effect/gibspawner/ipc, /obj/effect/gibspawner/ipc/bodypartless)
 	mutanttongue = /obj/item/organ/tongue/robot/ipc
 	mutant_heart = /obj/item/organ/heart/ipc
@@ -18,10 +20,14 @@
 	mutantliver = /obj/item/organ/liver/ipc
 	mutantstomach = /obj/item/organ/stomach/ipc
 	mutanteyes = /obj/item/organ/eyes/ipc
+	var/list/initial_inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH)
 
 	exotic_bloodtype = "HF"
 
 	var/datum/action/innate/monitor_change/screen
+
+/datum/species/ipc/after_equip_job(datum/job/J, mob/living/carbon/human/H)
+	H.grant_language(/datum/language/drone)
 
 /datum/species/ipc/on_species_gain(mob/living/carbon/human/C)
 	C.grant_language(/datum/language/machine)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IPCs:

- Are now immune to viruses and suffocation. Why would a machine need air?
- Takes twice as much burn damage. There are a loooot of metal and plastic parts that could get melted.
- Can no longer be butchered for meat. Previously they dropped a subtype of meat/slab/human/mutant, which is a holdover from them just being human reskins.
- Gains drone language, just as a ribbon.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Racial diversity never hurts. This turns IPCs from humans with funny voices to _a distinct race_ with benefits and drawbacks.

## Changelog
:cl:
Tweak: IPCs no longer drop meat.
Tweak: IPCs speak drone-ish
Balance: IPCs are immune to viruses/suffocation, but take twice as much burn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
