### PR TITLE
Flagellate the station with IPC charging cables

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -241,3 +241,61 @@
 	name = "chemical cybernetics implant"
 	desc = "A powerful cybernetic implant that contains chemical fabrication modules built into the user's arm."
 	contents = newlist(/obj/item/reagent_containers/hypospray/debug, /obj/item/gun/chem/debug, /obj/item/reagent_containers/chemical_tongue, /obj/item/fermichem/pHmeter)
+
+
+//Ported from Skyrat
+
+
+/obj/item/organ/cyberimp/arm/power_cord
+	name = "power cord implant"
+	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
+	contents = newlist(/obj/item/apc_powercord)
+	zone = "l_arm"
+
+/obj/item/apc_powercord
+	name = "power cord"
+	desc = "An internal power cord hooked up to a battery. Useful if you run on electricity. Not so much otherwise."
+	icon = 'icons/obj/power.dmi'
+	icon_state = "wire1"
+
+/obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!istype(target, /obj/machinery/power/apc) || !ishuman(user) || !proximity_flag)
+		return ..()
+	user.changeNext_move(CLICK_CD_MELEE)
+	var/obj/machinery/power/apc/A = target
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/stomach/robot_ipc/cell = locate(/obj/item/organ/stomach/ipc) in H.internal_organs
+	if(A.cell && A.cell.charge > 0)
+		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+			to_chat(user, "<span class='warning'>You are already fully charged!</span>")
+			return
+		else
+			powerdraw_loop(A, H)
+			return
+
+	to_chat(user, "<span class='warning'>There is no charge to draw from that APC.</span>")
+
+/obj/item/apc_powercord/proc/powerdraw_loop(obj/machinery/power/apc/A, mob/living/carbon/human/H)
+	H.visible_message("<span class='notice'>[H] inserts a power connector into the [A].</span>", "<span class='notice'>You begin to draw power from the [A].</span>")
+	while(do_after(H, 10, target = A))
+		if(loc != H)
+			to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
+			break
+		if(A.cell.charge == 0)
+			to_chat(H, "<span class='warning'>The [A] doesn't have enough charge to spare.</span>")
+			break
+		A.charging = 1
+		if(A.cell.charge >= 500)
+			do_sparks(1, FALSE, A)
+			H.nutrition += 50
+			A.cell.charge -= 150
+			to_chat(H, "<span class='notice'>You siphon off some of the stored charge for your own use.</span>")
+		else
+			H.nutrition += A.cell.charge/10
+			A.cell.charge = 0
+			to_chat(H, "<span class='notice'>You siphon off as much as the [A] can spare.</span>")
+			break
+		if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
+			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+			break
+	H.visible_message("<span class='notice'>[H] unplugs from the [A].</span>", "<span class='notice'>You unplug from the [A].</span>")

--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -8,6 +8,7 @@
 	sexes = 0
 	species_traits = list(MUTCOLORS,NOEYES,NOTRANSSTING)
 	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH)
+	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	burnmod = 2
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna")


### PR DESCRIPTION
Allows IPCs to regain nutrition by deploying a charging implant and draining APCs.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Ports over the IPC cable implants from Skyrat, allowing them to deploy a cable from their arm and drain APCs to regain nutrition.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Robot is machine, machine eat power, robot power cable eat power.

## Changelog
:cl:
add: New charging cable implant that allows IPC stomachs to be filled. You can extract it and put it in another race, but... why would you?
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
